### PR TITLE
Add support for regenerating last reply with a new random seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ LLM-UI is a native UI for large language models, it uses [llama.cpp](https://git
 
 ## Features
 - Support for multiple characters, each with its own context. Try `./llm-ui -c configs/config-multi-char.json` as an exampe. https://github.com/axim2/llm-ui/pull/1
+- Regeneration of last reply with a new random seed ("Regen" button in UI). https://github.com/axim2/llm-ui/pull/2
 - Shows LLM's output in real-time.
 - Supports all models which are supported by [llama.cpp](https://github.com/ggerganov/llama.cpp).
 - Lightweight native application, doesn't require network connectivity, Python, or Node.js.

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -53,6 +53,7 @@ private:
     void OnPause(wxCommandEvent& event);
     void OnStop(wxCommandEvent& event);
     void OnReloadUI(wxCommandEvent& event);
+    void OnDebug(wxCommandEvent& event);
 
     void WebviewOnLoaded(wxWebViewEvent& event);
 
@@ -89,6 +90,7 @@ enum {
     MENU_SAVE = 10,
     MENU_SAVE_AS = 11,
     MENU_SAVE_CONVERSATION = 12,
+    MENU_DEBUG = 13,
     MENU_Reload_UI = wxID_HIGHEST + 1
 };
 

--- a/src/model.h
+++ b/src/model.h
@@ -47,9 +47,10 @@ public:
     bool LoadModel(std::string model_path);
     
     gpt_params GetGPTParams(void); 
-    bool SetGPTParams(gpt_params new_params, bool update_seed = false);
+    bool SetGPTParams(gpt_params new_params, bool update_seed = false, int32_t *new_seed = 0);
     
     bool GenerateOutput(std::string prompt);
+    bool RegenerateOutput(void);
 
     bool ToggleGeneration(void); 
     bool StopGeneration(void);
@@ -66,6 +67,15 @@ private:
     
     gpt_params params;
     llama_context *ctx = nullptr;
+    
+    std::string old_input;
+    std::vector<uint8_t> old_state;
+    int n_past = 0;
+    int old_n_past = 0;
+    std::vector<llama_token> last_n_tokens;
+    std::vector<llama_token> old_last_n_tokens;
+    int n_outputs; // how many outputs we have generated
+    
     inline static Webview *webview; // used for communication with the HTML UI
     inline static Config *config; // pointer to config class
     
@@ -79,7 +89,6 @@ private:
 
     int n_consumed;
     int char_index; // which character this models handles? 0 - first character
-    std::vector<llama_token> last_n_tokens;
         
     inline static console_state con_st;
     std::vector<llama_token> evaluated_tokens;

--- a/ui/default/index.html
+++ b/ui/default/index.html
@@ -11,6 +11,7 @@
   <div class="toolbar">
     <button class="toolbar-button" onclick="toggleGeneration()">Pause</button>
     <button class="toolbar-button" onclick="stopGeneration()">Stop</button>
+    <button class="toolbar-button" onclick="Regenerate()" id="regen-button" disabled="true">Regen</button>
     <button class="toolbar-button" onclick="reloadParams()">Reload Params</button>
     <button class="toolbar-button" onclick="showSettingsUI()">Settings</button>
     Model: <select name="model" id="model" class="toolbar-button" onchange="loadModel(this.value)"></select>

--- a/ui/default/style.css
+++ b/ui/default/style.css
@@ -161,12 +161,17 @@ body {
   height: 10%;
 }
 
+/* buttons for toolbar */
 .toolbar-button {
   margin: 5px;
   color: #004;
   font-size: small;
 }
 
+.toolbar-button:disabled {
+  color: #77b;
+}
+  
 .base-prompt {
   overflow: hidden;
   display: -webkit-box;

--- a/userscripts/base.js
+++ b/userscripts/base.js
@@ -112,6 +112,10 @@ function waitingForInput() {
     return;
   }
   
+  // enable regen button just in case
+  var regen_button = document.getElementById('regen-button');
+  regen_button.disabled = false;
+  
   updateStatusbar('Reverse prompt found, waiting for input, next char: ' +
     params.char_names[current_char]);
 }
@@ -124,7 +128,7 @@ function generationStopped(time) {
   // add last message to the log
   if (tmplog.length > 0) {
     log.push(tmplog);
-    tmplog="";
+    tmplog = "";
   }
 
   statusbar.textContent = "Finished generating...";
@@ -179,6 +183,35 @@ function stopGeneration() {
       first_run[i] = true;
     prompt_parsed = false;
 }
+
+
+// regenerates character's last reply
+function Regenerate() {
+
+  previous_char = current_char - 1;
+  if (previous_char < 0)
+    previous_char = params.n_chars - 1;
+  
+  if (first_run[previous_char])
+    return;
+
+  // remove previous messagebox and entry from the log
+  let last_messagebox = Array.from(document.querySelectorAll('.left-msg')).pop();
+  chat_elem.removeChild(last_messagebox);
+  log.pop()
+  
+  current_char = previous_char;
+
+  model_list.disabled = true;
+  appendCharMessage("", current_char);
+  
+  let command = {};
+  command.cmd = "regenerate";
+  command.params = {};
+  command.params.char_index = current_char;
+  window.command.postMessage(command);
+}
+
 
 function reloadParams() {
     let command = {};
@@ -400,7 +433,7 @@ function processUserInput(input_text) {
       command.params.prompt = base_prompt[current_char] + "\n" + base_log[current_char].join("\n") + "\n";      
     }
     first_run[current_char] = false;
-    
+
   } else {
     command.cmd = "continue generation";
     command.params = {};


### PR DESCRIPTION
Check the console output for the new seed that is used to generate a new reply. 
Note: regenerating first reply is slow since it requires reprocessing the whole prompt.